### PR TITLE
Adds missing cells array

### DIFF
--- a/containerless/example-lightweight.ipynb
+++ b/containerless/example-lightweight.ipynb
@@ -1,4 +1,6 @@
 {
+ "cells": [
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
I'm just starting to learn Kubeflow and I was following your (very helpful) intro on YT. I hit the error uploading the Jupyter notebook file because the start of the cells array was missing. This PR should solve the problem.
![image](https://user-images.githubusercontent.com/2802359/95820408-c73d1000-0d73-11eb-99c1-a71798803775.png)
